### PR TITLE
タイムテーブルを公開する

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,201 @@
       <hr>
       <h3 id="schedule">スケジュール</h3>
       <p>(イベントの性質上、進行状況により時間が前後する場合がございます。ご了承下さい）</p>
+      <table class="fa-border">
+        <tr class="fa-border">
+          <th class="fa-border">13:30</th>
+          <td colspan="2">開場</td>
+        </tr>
+        <tr class="fa-border">
+          <th rowspan="15" class="fa-border">14:00 〜 15:30</th>
+          <td colspan="2">ライトニングトーク前半戦</td>
+        </tr>
+        <tr class="fa-border">
+          <td>五十嵐邦明 (Tokyu.rb)</td>
+          <td>進行と会場に関するご案内</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ビールスポンサー　サントリー様</td>
+          <td>ザ・プレミアム・モルツの美味しさの秘密</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ビールスポンサー　サントリー様</td>
+          <td>キャンペーンのご説明</td>
+        </tr>
+        <tr class="fa-border">
+          <td>会場スポンサー　VOYAGE GROUP様</td>
+          <td>会場説明</td>
+        </tr>
+        <tr class="fa-border">
+          <td>@yucao24hours(スタッフ)</td>
+          <td>投票アプリ説明</td>
+        </tr>
+        <tr class="fa-border">
+          <td>joker1007</td>
+          <td>Rubykaigi drinkup日本酒スーパーバイザーによる5分で分かるやさしい日本酒</td>
+        </tr>
+        <tr class="fa-border">
+          <td>伊藤 浩一 (@koic)</td>
+          <td>RubyKaigiのDrinkupを支える技術</td>
+        </tr>
+        <tr class="fa-border">
+          <td>a_matsuda</td>
+          <td>RubyKaigiはなぜチケットが万単位で公用語が英語なのか？</td>
+        </tr>
+        <tr class="fa-border">
+          <td>Toshio Maki</td>
+          <td>メール製品を作って気づいたmailライブラリの光と闇について語る</td>
+        </tr>
+        <tr class="fa-border">
+          <td>菅原元気</td>
+          <td>pt-osc的何かとmigrationのすりあわせについて</td>
+        </tr>
+        <tr class="fa-border">
+          <td>大久保英樹 / oakbow</td>
+          <td>Rubyist のためのフィリピン留学</td>
+        </tr>
+        <tr class="fa-border">
+          <td>SHIOYA, Hiromu / @kwappa</td>
+          <td>オーバー・フォーティから始める高校生活</td>
+        </tr>
+        <tr>
+          <td>zunda</td>
+          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ryopeko</td>
+          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">15:30 〜 15:45</th>
+          <td colspan="2">抽選LT抽選/休憩</td>
+        </tr>
+        <tr>
+          <th rowspan="16" class="fa-border">15:45 〜 17:15</th>
+          <td colspan="2">ライトニングトーク（何？）戦</td>
+        </tr>
+        <!-- スポンサー枠 -->
+        <tr class="fa-border">
+          <td>esaスポンサー  esa LLC様</td>
+          <td>未定</td>
+        </tr>
+        <tr class="fa-border">
+          <td>若杉 洋文</td>
+          <td>Rubyと戯れるOSS DTM</td>
+        </tr>
+        <tr class="fa-border">
+          <td>羽根田洋</td>
+          <td>またここで会おう、営業とエンジニアの距離を縮めて分かったこと</td>
+        </tr>
+        <tr>
+          <td>k0kubun</td>
+          <td>私がRails 5に入れたパッチとその背景</td>
+        </tr>
+        <tr class="fa-border">
+          <td>tdakak</td>
+          <td>オフィスのない会社で働いてみた</td>
+        </tr>
+        <tr class="fa-border">
+          <td>内山高広 (@highwide)</td>
+          <td>韻を踏むプログラムは書けるか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>河野 誠(ginkouno)</td>
+          <td>Tokyu.rbとは何だったのか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>野中哲</td>
+          <td>smsの送信・音声通話を発信するgemの紹介</td>
+        </tr>
+        <tr>
+          <td>安田篤史</td>
+          <td>苦いお酒が好きな人のためのコードの苦味の味わい方</td>
+        </tr>
+        <tr class="fa-border">
+          <td>みよひで</td>
+          <td>るびまを支えるRubyと人の力。そして未来のるびま（案）</td>
+        </tr>
+        <tr class="fa-border">
+          <td>川村 徹 (@tkawa)</td>
+          <td>ビールビーpresents Rubyのように赤いビールのすすめ</td>
+        </tr>
+        <tr class="fa-border">
+          <td>森 賢児 (morizyun)</td>
+          <td>英語で広がるRubyの世界</td>
+        </tr>
+        <tr class="fa-border">
+          <td>onk</td>
+          <td>これは使える！社内用 sinatra app 20 連発！</td>
+        </tr>
+        <tr>
+          <td>takiy33</td>
+          <td>最近コードレビューで困っていること</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">17:15 〜 17:30</th>
+          <td colspan="2">休憩</td>
+        </tr>
+        <tr class="fa-border">
+          <th rowspan="11" class="fa-border">17:30 〜 18:30</th>
+          <td colspan="2">ライトニングトーク（何？）戦</td>
+        </tr>
+        <tr class="fa-border">
+          <td>若杉 洋文</td>
+          <td>Rubyと戯れるOSS DTM</td>
+        </tr>
+        <tr class="fa-border">
+          <td>大久保英樹 / oakbow</td>
+          <td>Rubyist のためのフィリピン留学</td>
+        </tr>
+        <tr class="fa-border">
+          <td>SHIOYA, Hiromu / @kwappa</td>
+          <td>オーバー・フォーティから始める高校生活</td>
+        </tr>
+        <tr>
+          <td>zunda</td>
+          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ryopeko</td>
+          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+        </tr>
+        <tr class="fa-border">
+          <td>若杉 洋文</td>
+          <td>Rubyと戯れるOSS DTM</td>
+        </tr>
+        <tr class="fa-border">
+          <td>大久保英樹 / oakbow</td>
+          <td>Rubyist のためのフィリピン留学</td>
+        </tr>
+        <tr class="fa-border">
+          <td>SHIOYA, Hiromu / @kwappa</td>
+          <td>オーバー・フォーティから始める高校生活</td>
+        </tr>
+        <tr>
+          <td>zunda</td>
+          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+        </tr>
+        <tr class="fa-border">
+          <td>ryopeko</td>
+          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">18:30 〜 19:00</th>
+          <!-- TODO: ここ↓の表記をどうするか確認する -->
+          <td colspan="2">基調講演投票・登壇者発表・休憩</td>
+        </tr>
+        <tr>
+          <th class="fa-border">19:00 〜 19:10</th>
+          <td colspan="2">基調講演[飯]</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">19:10 〜 19:20</th>
+          <td colspan="2">基調講演[LT]</td>
+        </tr>
+        <tr class="fa-border">
+          <th class="fa-border">19:20</th><td colspan="2">閉会の一本締め</td>
+        </tr>
+      </table>
       <hr>
       <!-- TODO 前回の様子をここに入れる -->
       <h3>スタッフ</h3>

--- a/index.html
+++ b/index.html
@@ -164,65 +164,57 @@
           <td colspan="2">抽選LT抽選/休憩</td>
         </tr>
         <tr>
-          <th rowspan="16" class="fa-border">15:45 〜 17:15</th>
+          <th rowspan="13" class="fa-border">15:45 〜 17:15</th>
           <td colspan="2">ライトニングトーク第二部</td>
         </tr>
         <!-- スポンサー枠 -->
         <tr class="fa-border">
-          <td>esaスポンサー  esa LLC様</td>
-          <td>未定</td>
+          <td>esaスポンサー esa LLC様</td>
+          <td>TBD</td>
         </tr>
         <tr class="fa-border">
-          <td>若杉 洋文</td>
-          <td>Rubyと戯れるOSS DTM</td>
+          <td>シャツスポンサー spice life様</td>
+          <td><a href="https://tmix.jp/">TMIX</a>, <a href="https://steers.jp/">STEERS</a>スポンサートーク</td>
         </tr>
         <tr class="fa-border">
-          <td>羽根田洋</td>
-          <td>またここで会おう、営業とエンジニアの距離を縮めて分かったこと</td>
-        </tr>
-        <tr>
-          <td>k0kubun</td>
-          <td>私がRails 5に入れたパッチとその背景</td>
-        </tr>
-        <tr class="fa-border">
-          <td>tdakak</td>
-          <td>オフィスのない会社で働いてみた</td>
-        </tr>
-        <tr class="fa-border">
-          <td>内山高広 (@highwide)</td>
-          <td>韻を踏むプログラムは書けるか</td>
-        </tr>
-        <tr class="fa-border">
-          <td>河野 誠(ginkouno)</td>
-          <td>Tokyu.rbとは何だったのか</td>
-        </tr>
-        <tr class="fa-border">
-          <td>野中哲</td>
-          <td>smsの送信・音声通話を発信するgemの紹介</td>
-        </tr>
-        <tr>
           <td>安田篤史</td>
-          <td>苦いお酒が好きな人のためのコードの苦味の味わい方</td>
+          <td>本当にあった怖いコード2017夏</td>
         </tr>
         <tr class="fa-border">
-          <td>みよひで</td>
-          <td>るびまを支えるRubyと人の力。そして未来のるびま（案）</td>
+          <td>mtsmfm</td>
+          <td>Rails System Test on Docker</td>
         </tr>
         <tr class="fa-border">
-          <td>川村 徹 (@tkawa)</td>
-          <td>ビールビーpresents Rubyのように赤いビールのすすめ</td>
+          <td>Shinichi Nakagawa(野球の人/Retty.Inc)</td>
+          <td>Rubyではじめる野球データ分析〜Pythonを添えて</td>
         </tr>
         <tr class="fa-border">
-          <td>森 賢児 (morizyun)</td>
-          <td>英語で広がるRubyの世界</td>
+          <td>koic</td>
+          <td>アプリがパッチにまみれたら</td>
         </tr>
         <tr class="fa-border">
-          <td>onk</td>
-          <td>これは使える！社内用 sinatra app 20 連発！</td>
+          <td>2celeb</td>
+          <td>とあるソシャゲのbotを1年間作り続けた話</td>
+        </tr>
+        <tr class="fa-border">
+          <td>joker1007</td>
+          <td>Rubyistの皆さん、まだMacで消耗してるの？</td>
+        </tr>
+        <tr class="fa-border">
+          <td>cnosuke</td>
+          <td>Ruby + gRPCは果たして実用に耐えうるのだろうか</td>
         </tr>
         <tr>
-          <td>takiy33</td>
-          <td>最近コードレビューで困っていること</td>
+          <td>sue445</td>
+          <td>パーフェクトrubicure</td>
+        </tr>
+        <tr class="fa-border">
+          <td>@chiastolite</td>
+          <td>Rubyistなら知っておきたい広島のこと</td>
+        </tr>
+        <tr class="fa-border">
+          <td>今　佑介</td>
+          <td>Railsアプリの長期運用のコツ 未使用コードを削除せよ</td>
         </tr>
         <tr class="fa-border">
           <th class="fa-border">17:15 〜 17:30</th>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
           <td colspan="2">抽選LT抽選/休憩</td>
         </tr>
         <tr>
-          <th rowspan="13" class="fa-border">15:45 〜 17:15</th>
+          <th rowspan="16" class="fa-border">15:45 〜 17:15</th>
           <td colspan="2">ライトニングトーク第二部</td>
         </tr>
         <!-- スポンサー枠 -->
@@ -217,6 +217,18 @@
           <td>Railsアプリの長期運用のコツ 未使用コードを削除せよ</td>
         </tr>
         <tr class="fa-border">
+          <td>抽選 LT 当選者1</td>
+          <td>抽選 LT 1 枠目</td>
+        </tr>
+        <tr class="fa-border">
+          <td>抽選 LT 当選者2</td>
+          <td>抽選 LT 2 枠目 </td>
+        </tr>
+        <tr class="fa-border">
+          <td>抽選 LT 当選者3</td>
+          <td>抽選 LT 3 枠目</td>
+        </tr>
+        <tr class="fa-border">
           <th class="fa-border">17:15 〜 17:30</th>
           <td colspan="2">休憩</td>
         </tr>
@@ -263,7 +275,7 @@
         <tr class="fa-border">
           <th class="fa-border">18:30 〜 19:00</th>
           <!-- TODO: ここ↓の表記をどうするか確認する -->
-          <td colspan="2">基調講演投票・登壇者発表・休憩・抽選LT</td>
+          <td colspan="2">基調講演投票・登壇者発表・休憩</td>
         </tr>
         <tr>
           <th class="fa-border">19:00 〜 19:10</th>

--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
           <td>cnosuke</td>
           <td>Ruby + gRPCは果たして実用に耐えうるのだろうか</td>
         </tr>
-        <tr>
+        <tr class="fa-border">
           <td>sue445</td>
           <td>パーフェクトrubicure</td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -221,48 +221,44 @@
           <td colspan="2">休憩</td>
         </tr>
         <tr class="fa-border">
-          <th rowspan="11" class="fa-border">17:30 〜 18:30</th>
+          <th rowspan="10" class="fa-border">17:30 〜 18:30</th>
           <td colspan="2">ライトニングトーク第三部</td>
         </tr>
         <tr class="fa-border">
-          <td>若杉 洋文</td>
-          <td>Rubyと戯れるOSS DTM</td>
+          <td>小川 伸一郎</td>
+          <td>技術顧問にならないほうがいい3つの理由</td>
         </tr>
         <tr class="fa-border">
-          <td>大久保英樹 / oakbow</td>
-          <td>Rubyist のためのフィリピン留学</td>
+          <td>iTume</td>
+          <td>Rubyに出会って人生変わっちゃった話</td>
         </tr>
         <tr class="fa-border">
-          <td>SHIOYA, Hiromu / @kwappa</td>
-          <td>オーバー・フォーティから始める高校生活</td>
-        </tr>
-        <tr>
-          <td>zunda</td>
-          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+          <td>中島 滋</td>
+          <td>RSpecで非同期関数をテストする</td>
         </tr>
         <tr class="fa-border">
-          <td>ryopeko</td>
-          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+          <td>樽家昌也</td>
+          <td>細かいrubyの話？(仮)</td>
         </tr>
         <tr class="fa-border">
-          <td>若杉 洋文</td>
-          <td>Rubyと戯れるOSS DTM</td>
+          <td>yancya</td>
+          <td>どう書く日記</td>
         </tr>
         <tr class="fa-border">
-          <td>大久保英樹 / oakbow</td>
-          <td>Rubyist のためのフィリピン留学</td>
+          <td>秒速284km</td>
+          <td>はじめて勉強会を運営して学んだこと Rails Developers Meetup 編</td>
         </tr>
         <tr class="fa-border">
-          <td>SHIOYA, Hiromu / @kwappa</td>
-          <td>オーバー・フォーティから始める高校生活</td>
-        </tr>
-        <tr>
-          <td>zunda</td>
-          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+          <td>茂木勇</td>
+          <td>マストドンでCircleCI2.0を導入したらテスト時間が半分になったよー</td>
         </tr>
         <tr class="fa-border">
-          <td>ryopeko</td>
-          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+          <td>サキ</td>
+          <td>RSpec でメールサンプルの管理</td>
+        </tr>
+        <tr class="fa-border">
+          <td>小芝 敏明</td>
+          <td>Ruby、Mastodon、そしてPawoo</td>
         </tr>
         <tr class="fa-border">
           <th class="fa-border">18:30 〜 19:00</th>

--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
         <tr class="fa-border">
           <th class="fa-border">18:30 〜 19:00</th>
           <!-- TODO: ここ↓の表記をどうするか確認する -->
-          <td colspan="2">基調講演投票・登壇者発表・休憩</td>
+          <td colspan="2">基調講演投票・登壇者発表・休憩・抽選LT</td>
         </tr>
         <tr>
           <th class="fa-border">19:00 〜 19:10</th>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
           <td colspan="2">開場</td>
         </tr>
         <tr class="fa-border">
-          <th rowspan="15" class="fa-border">14:00 〜 15:30</th>
+          <th rowspan="16" class="fa-border">14:00 〜 15:30</th>
           <td colspan="2">ライトニングトーク第一部</td>
         </tr>
         <tr class="fa-border">
@@ -120,40 +120,44 @@
           <td>投票アプリ説明</td>
         </tr>
         <tr class="fa-border">
-          <td>joker1007</td>
-          <td>Rubykaigi drinkup日本酒スーパーバイザーによる5分で分かるやさしい日本酒</td>
+          <td>k0kubun</td>
+          <td>The Architecture of Haml 5</td>
         </tr>
         <tr class="fa-border">
-          <td>伊藤 浩一 (@koic)</td>
-          <td>RubyKaigiのDrinkupを支える技術</td>
+          <td>川村 徹 (@tkawa)</td>
+          <td>続・JSON APIとフォーマットの話</td>
         </tr>
         <tr class="fa-border">
-          <td>a_matsuda</td>
-          <td>RubyKaigiはなぜチケットが万単位で公用語が英語なのか？</td>
+          <td>cesare</td>
+          <td>Rails の辛みを回避するための処方箋</td>
         </tr>
         <tr class="fa-border">
-          <td>Toshio Maki</td>
-          <td>メール製品を作って気づいたmailライブラリの光と闇について語る</td>
+          <td>ujihisa</td>
+          <td>Vim</td>
         </tr>
         <tr class="fa-border">
-          <td>菅原元気</td>
-          <td>pt-osc的何かとmigrationのすりあわせについて</td>
+          <td>上杉隆史</td>
+          <td>Ruby On Railsを利用したサービスで特定のユーザ(〇〇〇万人)に何らかの告知をするための効率的な方法</td>
         </tr>
         <tr class="fa-border">
-          <td>大久保英樹 / oakbow</td>
-          <td>Rubyist のためのフィリピン留学</td>
+          <td>Akira Nonaka</td>
+          <td>Rubyで電話する、電話を受ける</td>
         </tr>
         <tr class="fa-border">
-          <td>SHIOYA, Hiromu / @kwappa</td>
-          <td>オーバー・フォーティから始める高校生活</td>
-        </tr>
-        <tr>
-          <td>zunda</td>
-          <td>Railsの日付とか時刻オブジェクトたちはどこのタイムゾーンにいるでしょうか</td>
+          <td>さとうたつや</td>
+          <td>Ruby on Rails on Azure （仮）</td>
         </tr>
         <tr class="fa-border">
-          <td>ryopeko</td>
-          <td>Kaizen Platform で行っている Kaizen Week というイベントで継続的にサービスを改善しているお話</td>
+          <td>shigemk2</td>
+          <td>別にRubyistではないのだけれどノリと勢いでRubyのOSSに貢献した気持ち</td>
+        </tr>
+        <tr class="fa-border">
+          <td>onk</td>
+          <td>RuboCop: Ragnarok</td>
+        </tr>
+        <tr class="fa-border">
+          <td>mozamimy</td>
+          <td>SSH configuration meets Ruby <3</td>
         </tr>
         <tr class="fa-border">
           <th class="fa-border">15:30 〜 15:45</th>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
           <td>会場説明</td>
         </tr>
         <tr class="fa-border">
-          <td>@yucao24hours(スタッフ)</td>
+          <td>@yucao24hours(Tokyu.rb)</td>
           <td>投票アプリ説明</td>
         </tr>
         <tr class="fa-border">

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         </tr>
         <tr class="fa-border">
           <th rowspan="15" class="fa-border">14:00 〜 15:30</th>
-          <td colspan="2">ライトニングトーク前半戦</td>
+          <td colspan="2">ライトニングトーク第一部</td>
         </tr>
         <tr class="fa-border">
           <td>五十嵐邦明 (Tokyu.rb)</td>
@@ -161,7 +161,7 @@
         </tr>
         <tr>
           <th rowspan="16" class="fa-border">15:45 〜 17:15</th>
-          <td colspan="2">ライトニングトーク（何？）戦</td>
+          <td colspan="2">ライトニングトーク第二部</td>
         </tr>
         <!-- スポンサー枠 -->
         <tr class="fa-border">
@@ -226,7 +226,7 @@
         </tr>
         <tr class="fa-border">
           <th rowspan="11" class="fa-border">17:30 〜 18:30</th>
-          <td colspan="2">ライトニングトーク（何？）戦</td>
+          <td colspan="2">ライトニングトーク第三部</td>
         </tr>
         <tr class="fa-border">
           <td>若杉 洋文</td>


### PR DESCRIPTION
## 概要

tqrk11 のタイムテーブルを公開するための準備をします。

## TODO
- [x] 時間配分を今年用に変える
- [x] 実行委員長の名前を igaiga さんのものに変える
- [x] 今年は三分構成なので `前半戦` `後半戦` のような用語だとちょっと落ち着かないので、ほかのなにかに変える => `第 n 部` という表記にしてみた。
- [x] esa さまのスポンサー LT タイトル（公開日までに間に合わなければ後日に別 PR）
- [x] spice life さまのスポンサー LT タイトル（公開日までに間に合わなければ後日に別 PR）
- [x] `基調講演投票・登壇者発表・休憩` の部分に `acceptLT?` `バッファ休憩` の表記を入れるか確認する https://github.com/yucao24hours/tokyurubykaigi/issues/64
- [x] 発表順を調整する
- [x] 発表者とタイトルを記入する
